### PR TITLE
Serve frontend build from Express + Render build fix

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: node
     plan: free
     autoDeploy: true
-    buildCommand: npm install && npm run build:backend && npx prisma generate
+    buildCommand: npm ci --include=dev && npx prisma generate && npx vite build && npm run build:backend
     startCommand: npx prisma migrate deploy && node dist/backend/server.js
     envVars:
       - key: NODE_VERSION
@@ -17,4 +17,7 @@ services:
         sync: false
       - key: PORT
         value: 10000
+      - key: VITE_API_URL
+        value: /api
+
     healthCheckPath: /health

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import cors from 'cors'
 import dotenv from 'dotenv'
 import { PrismaClient } from '@prisma/client'
+import path from 'path'
 
 // Routes
 import authRoutes from './routes/auth.routes'
@@ -28,27 +29,6 @@ app.use(cors())
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 
-// Welcome page
-app.get('/', (_req, res) => {
-  res.json({
-    name: 'Lucy3000 API',
-    version: '1.0.0',
-    status: 'running',
-    endpoints: {
-      health: '/health',
-      auth: '/api/auth',
-      clients: '/api/clients',
-      appointments: '/api/appointments',
-      services: '/api/services',
-      products: '/api/products',
-      sales: '/api/sales',
-      cash: '/api/cash',
-      notifications: '/api/notifications',
-      reports: '/api/reports',
-      dashboard: '/api/dashboard'
-    }
-  })
-})
 
 // Health check
 app.get('/health', (_req, res) => {
@@ -66,6 +46,16 @@ app.use('/api/cash', cashRoutes)
 app.use('/api/notifications', notificationRoutes)
 app.use('/api/reports', reportRoutes)
 app.use('/api/dashboard', dashboardRoutes)
+// Static frontend build (Vite)
+const clientDir = path.resolve(__dirname, '..', '..')
+app.use(express.static(clientDir))
+
+// SPA fallback: send index.html for non-API routes
+app.get('*', (req, res, next) => {
+  if (req.path.startsWith('/api') || req.path.startsWith('/health')) return next()
+  res.sendFile(path.join(clientDir, 'index.html'))
+})
+
 
 // Error handling
 app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {


### PR DESCRIPTION
This PR makes the web service serve the React (Vite) frontend and ensures Render builds the client:

- Express:
  - Remove JSON welcome at `/`
  - Serve static files from `dist` and add SPA fallback to `index.html` for non-API routes

- Render (`render.yaml`):
  - Build command now runs Vite build (`npx vite build`) and then compiles backend
  - Add `VITE_API_URL=/api` so the client hits the same-origin API

This should fix the issue where opening https://lucy3000.onrender.com shows the API JSON instead of the app.

Please review and merge. Auto-deploy should pick it up.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author