### PR TITLE
Fix: serve correct dist path from Express

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: node
     plan: free
     autoDeploy: true
-    buildCommand: npm install && npm run build:backend && npx prisma generate
+    buildCommand: npm ci --include=dev && npx prisma generate && npx vite build && npm run build:backend
     startCommand: npx prisma migrate deploy && node dist/backend/server.js
     envVars:
       - key: NODE_VERSION
@@ -17,4 +17,7 @@ services:
         sync: false
       - key: PORT
         value: 10000
+      - key: VITE_API_URL
+        value: /api
+
     healthCheckPath: /health

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import cors from 'cors'
 import dotenv from 'dotenv'
 import { PrismaClient } from '@prisma/client'
+import path from 'path'
 
 // Routes
 import authRoutes from './routes/auth.routes'
@@ -28,27 +29,6 @@ app.use(cors())
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 
-// Welcome page
-app.get('/', (_req, res) => {
-  res.json({
-    name: 'Lucy3000 API',
-    version: '1.0.0',
-    status: 'running',
-    endpoints: {
-      health: '/health',
-      auth: '/api/auth',
-      clients: '/api/clients',
-      appointments: '/api/appointments',
-      services: '/api/services',
-      products: '/api/products',
-      sales: '/api/sales',
-      cash: '/api/cash',
-      notifications: '/api/notifications',
-      reports: '/api/reports',
-      dashboard: '/api/dashboard'
-    }
-  })
-})
 
 // Health check
 app.get('/health', (_req, res) => {
@@ -66,6 +46,16 @@ app.use('/api/cash', cashRoutes)
 app.use('/api/notifications', notificationRoutes)
 app.use('/api/reports', reportRoutes)
 app.use('/api/dashboard', dashboardRoutes)
+// Static frontend build (Vite)
+const clientDir = path.resolve(__dirname, '..', '..')
+app.use(express.static(clientDir))
+
+// SPA fallback: send index.html for non-API routes
+app.get('*', (req, res, next) => {
+  if (req.path.startsWith('/api') || req.path.startsWith('/health')) return next()
+  res.sendFile(path.join(clientDir, 'index.html'))
+})
+
 
 // Error handling
 app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -47,7 +47,7 @@ app.use('/api/notifications', notificationRoutes)
 app.use('/api/reports', reportRoutes)
 app.use('/api/dashboard', dashboardRoutes)
 // Static frontend build (Vite)
-const clientDir = path.resolve(__dirname, '..', '..')
+const clientDir = path.resolve(__dirname, '..')
 app.use(express.static(clientDir))
 
 // SPA fallback: send index.html for non-API routes


### PR DESCRIPTION
Small follow-up fix to ensure Express serves the built Vite frontend correctly by pointing `clientDir` to the compiled `dist` directory relative to `dist/backend`.

```diff
- const clientDir = path.resolve(__dirname, '..', '..')
+ const clientDir = path.resolve(__dirname, '..')
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author