### PR TITLE
Fix: serve correct dist path from Express

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -47,7 +47,7 @@ app.use('/api/notifications', notificationRoutes)
 app.use('/api/reports', reportRoutes)
 app.use('/api/dashboard', dashboardRoutes)
 // Static frontend build (Vite)
-const clientDir = path.resolve(__dirname, '..', '..')
+const clientDir = path.resolve(__dirname, '..')
 app.use(express.static(clientDir))
 
 // SPA fallback: send index.html for non-API routes


### PR DESCRIPTION
Ensure Express serves the built Vite frontend correctly by pointing `clientDir` to the compiled `dist` directory relative to `dist/backend`.

```diff
- const clientDir = path.resolve(__dirname, '..', '..')
+ const clientDir = path.resolve(__dirname, '..')
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author