### PR TITLE
Add LAN ESC/POS ticket printer support

### DIFF
--- a/src/main/escpos.ts
+++ b/src/main/escpos.ts
@@ -1,0 +1,202 @@
+import net from 'node:net'
+import type { TicketPrintPayload } from '../shared/ticketPrinter'
+
+const ESC = 0x1b
+const GS = 0x1d
+const RECEIPT_WIDTH = 42
+
+const sanitizeText = (value: string) =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/€/g, 'EUR')
+    .replace(/[^\x20-\x7E]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const wrapText = (value: string, width: number) => {
+  const text = sanitizeText(value)
+  if (!text) {
+    return ['']
+  }
+
+  const words = text.split(' ')
+  const lines: string[] = []
+  let current = ''
+
+  for (const word of words) {
+    if (word.length > width) {
+      if (current) {
+        lines.push(current)
+        current = ''
+      }
+
+      for (let index = 0; index < word.length; index += width) {
+        lines.push(word.slice(index, index + width))
+      }
+
+      continue
+    }
+
+    const next = current ? `${current} ${word}` : word
+    if (next.length <= width) {
+      current = next
+      continue
+    }
+
+    lines.push(current)
+    current = word
+  }
+
+  if (current) {
+    lines.push(current)
+  }
+
+  return lines.length > 0 ? lines : ['']
+}
+
+const padLine = (left: string, right: string, width = RECEIPT_WIDTH) => {
+  const safeLeft = sanitizeText(left)
+  const safeRight = sanitizeText(right)
+  const space = Math.max(1, width - safeLeft.length - safeRight.length)
+  return `${safeLeft}${' '.repeat(space)}${safeRight}`.slice(0, width)
+}
+
+const centerLine = (value: string, width = RECEIPT_WIDTH) => {
+  const safe = sanitizeText(value)
+  if (safe.length >= width) {
+    return safe.slice(0, width)
+  }
+
+  const leftPad = Math.floor((width - safe.length) / 2)
+  return `${' '.repeat(leftPad)}${safe}`
+}
+
+const separator = '-'.repeat(RECEIPT_WIDTH)
+
+const command = (...bytes: number[]) => Buffer.from(bytes)
+const text = (value = '') => Buffer.from(`${value}\n`, 'ascii')
+
+export const buildEscPosTicketBuffer = (payload: TicketPrintPayload) => {
+  const parts: Buffer[] = [command(ESC, 0x40)]
+  const pushLine = (value = '') => {
+    parts.push(text(value))
+  }
+
+  parts.push(command(ESC, 0x61, 0x01))
+  parts.push(command(ESC, 0x45, 0x01))
+  for (const line of wrapText(payload.title || 'Lucy3000', RECEIPT_WIDTH)) {
+    pushLine(centerLine(line))
+  }
+  parts.push(command(ESC, 0x45, 0x00))
+
+  for (const line of wrapText(payload.subtitle || 'Ticket', RECEIPT_WIDTH)) {
+    pushLine(centerLine(line))
+  }
+
+  pushLine()
+  parts.push(command(ESC, 0x61, 0x00))
+  pushLine(separator)
+
+  const metadata = [
+    ['Ticket', payload.saleNumber],
+    ['Cliente', payload.customer],
+    ['Fecha', payload.createdAt],
+    ['Pago', payload.paymentMethod]
+  ] as const
+
+  for (const [label, value] of metadata) {
+    if (!value) continue
+    for (const line of wrapText(`${label}: ${value}`, RECEIPT_WIDTH)) {
+      pushLine(line)
+    }
+  }
+
+  pushLine(separator)
+
+  for (const item of payload.items || []) {
+    for (const line of wrapText(item.description, RECEIPT_WIDTH)) {
+      pushLine(line)
+    }
+
+    pushLine(
+      padLine(
+        `${Number(item.quantity).toFixed(2)} x ${Number(item.unitPrice).toFixed(2)}`,
+        Number(item.total).toFixed(2)
+      )
+    )
+  }
+
+  if ((payload.totals || []).length > 0) {
+    pushLine(separator)
+  }
+
+  for (const total of payload.totals || []) {
+    pushLine(padLine(total.label, total.value))
+  }
+
+  pushLine()
+  parts.push(command(ESC, 0x61, 0x01))
+  for (const line of wrapText(payload.footer || 'Gracias por tu visita', RECEIPT_WIDTH)) {
+    pushLine(centerLine(line))
+  }
+
+  pushLine()
+  pushLine()
+  pushLine()
+  parts.push(command(GS, 0x56, 0x00))
+
+  return Buffer.concat(parts)
+}
+
+type PrintNetworkTicketOptions = {
+  host: string
+  port: number
+  payload: TicketPrintPayload
+  timeoutMs?: number
+}
+
+export const printNetworkTicket = async ({
+  host,
+  port,
+  payload,
+  timeoutMs = 4000
+}: PrintNetworkTicketOptions) => {
+  const ticket = buildEscPosTicketBuffer(payload)
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false
+    const socket = net.createConnection({ host, port })
+
+    const finish = (error?: Error) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      socket.removeAllListeners()
+
+      if (error) {
+        socket.destroy()
+        reject(error)
+        return
+      }
+
+      resolve()
+    }
+
+    socket.setTimeout(timeoutMs)
+
+    socket.on('connect', () => {
+      socket.end(ticket, () => finish())
+    })
+
+    socket.on('timeout', () => {
+      finish(new Error(`Timeout conectando con la impresora (${host}:${port})`))
+    })
+
+    socket.on('error', (error) => {
+      finish(error)
+    })
+  })
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,6 +5,13 @@ import fs from 'fs'
 import { promises as fsPromises } from 'fs'
 import { pathToFileURL } from 'url'
 import { ChildProcess, spawn } from 'child_process'
+import { printNetworkTicket } from './escpos'
+import {
+  DEFAULT_TICKET_PRINTER_CONFIG,
+  normalizeTicketPrinterConfig,
+  validateTicketPrinterConfig
+} from '../shared/ticketPrinter'
+import type { TicketPrintPayload, TicketPrinterConfig } from '../shared/ticketPrinter'
 
 let mainWindow: BrowserWindow | null = null
 let backendProcess: ChildProcess | null = null
@@ -30,26 +37,6 @@ type ClientAssetManifest = {
   version: 1
   primaryPhotoId: string | null
   assets: StoredClientAsset[]
-}
-
-type TicketPrintPayload = {
-  title?: string
-  subtitle?: string
-  saleNumber?: string
-  customer?: string
-  createdAt?: string
-  paymentMethod?: string
-  items?: Array<{
-    description: string
-    quantity: number
-    unitPrice: number
-    total: number
-  }>
-  totals?: Array<{
-    label: string
-    value: string
-  }>
-  footer?: string
 }
 
 type AppPathName =
@@ -183,14 +170,15 @@ const buildAssetResponse = async (clientId: string, clientName: string) => {
   }
 }
 
-const getTicketPrinterConfig = async () =>
-  readJsonFile<{ ticketPrinterName: string | null }>(getPrinterConfigPath(), {
-    ticketPrinterName: null
-  })
+const getTicketPrinterConfig = async (): Promise<TicketPrinterConfig> => {
+  const config = await readJsonFile<unknown>(getPrinterConfigPath(), DEFAULT_TICKET_PRINTER_CONFIG)
+  return normalizeTicketPrinterConfig(config)
+}
 
-const setTicketPrinterConfig = async (ticketPrinterName: string | null) => {
-  await writeJsonFile(getPrinterConfigPath(), { ticketPrinterName })
-  return { ticketPrinterName }
+const setTicketPrinterConfig = async (config: unknown) => {
+  const normalizedConfig = normalizeTicketPrinterConfig(config)
+  await writeJsonFile(getPrinterConfigPath(), normalizedConfig)
+  return normalizedConfig
 }
 
 const waitForBackendReady = async (
@@ -554,16 +542,46 @@ ipcMain.handle('ticket:listPrinters', async () => {
   }))
 })
 
-ipcMain.handle('ticket:getPrinter', async () => getTicketPrinterConfig())
+ipcMain.handle('ticket:getConfig', async () => getTicketPrinterConfig())
+
+ipcMain.handle('ticket:setConfig', async (_, config: TicketPrinterConfig) => {
+  return setTicketPrinterConfig(config)
+})
+
+ipcMain.handle('ticket:getPrinter', async () => {
+  const config = await getTicketPrinterConfig()
+  return { ticketPrinterName: config.ticketPrinterName }
+})
 
 ipcMain.handle('ticket:setPrinter', async (_, printerName: string | null) => {
-  return setTicketPrinterConfig(printerName)
+  const currentConfig = await getTicketPrinterConfig()
+  return setTicketPrinterConfig({
+    ...currentConfig,
+    mode: 'system',
+    ticketPrinterName: printerName
+  })
 })
 
 ipcMain.handle('ticket:print', async (_, payload: TicketPrintPayload) => {
   const config = await getTicketPrinterConfig()
-  if (!config.ticketPrinterName) {
-    return { success: false, error: 'No hay impresora de tickets configurada' }
+  const validation = validateTicketPrinterConfig(config)
+
+  if (!validation.valid) {
+    return { success: false, error: validation.error }
+  }
+
+  if (config.mode === 'network') {
+    try {
+      await printNetworkTicket({
+        host: config.networkHost,
+        port: config.networkPort,
+        payload
+      })
+
+      return { success: true }
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : error }
+    }
   }
 
   const ticketWindow = new BrowserWindow({

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6,6 +6,7 @@ import { promises as fsPromises } from 'fs'
 import { pathToFileURL } from 'url'
 import { ChildProcess, spawn } from 'child_process'
 import { printNetworkTicket } from './escpos'
+import { buildTicketHtml } from '../shared/ticketHtml'
 import {
   DEFAULT_TICKET_PRINTER_CONFIG,
   normalizeTicketPrinterConfig,
@@ -256,112 +257,6 @@ const stopBackend = () => {
     backendProcess.kill()
     backendProcess = null
   }
-}
-
-const buildTicketHtml = (payload: TicketPrintPayload) => {
-  const itemsHtml = (payload.items || [])
-    .map(
-      (item) => `
-        <tr>
-          <td class="desc">${item.description}</td>
-          <td class="qty">${item.quantity}</td>
-          <td class="amount">${item.total.toFixed(2)} €</td>
-        </tr>
-      `
-    )
-    .join('')
-
-  const totalsHtml = (payload.totals || [])
-    .map(
-      (total) => `
-        <div class="total-row">
-          <span>${total.label}</span>
-          <strong>${total.value}</strong>
-        </div>
-      `
-    )
-    .join('')
-
-  return `
-    <!DOCTYPE html>
-    <html lang="es">
-      <head>
-        <meta charset="UTF-8" />
-        <style>
-          body {
-            font-family: "Segoe UI", sans-serif;
-            width: 58mm;
-            margin: 0 auto;
-            padding: 8px;
-            color: #111827;
-            font-size: 12px;
-          }
-          h1 {
-            font-size: 18px;
-            margin: 0 0 4px;
-            text-align: center;
-          }
-          .muted {
-            text-align: center;
-            color: #4b5563;
-            margin-bottom: 8px;
-          }
-          .meta {
-            border-top: 1px dashed #9ca3af;
-            border-bottom: 1px dashed #9ca3af;
-            padding: 6px 0;
-            margin-bottom: 8px;
-          }
-          .meta div,
-          .total-row {
-            display: flex;
-            justify-content: space-between;
-            gap: 8px;
-            margin: 2px 0;
-          }
-          table {
-            width: 100%;
-            border-collapse: collapse;
-            margin-bottom: 8px;
-          }
-          td {
-            padding: 2px 0;
-            vertical-align: top;
-          }
-          .qty,
-          .amount {
-            white-space: nowrap;
-            text-align: right;
-          }
-          .desc {
-            width: 100%;
-            padding-right: 6px;
-          }
-          .footer {
-            border-top: 1px dashed #9ca3af;
-            padding-top: 8px;
-            text-align: center;
-            color: #4b5563;
-          }
-        </style>
-      </head>
-      <body>
-        <h1>${payload.title || 'Lucy3000'}</h1>
-        <div class="muted">${payload.subtitle || 'Ticket'}</div>
-        <div class="meta">
-          ${payload.saleNumber ? `<div><span>Ticket</span><strong>${payload.saleNumber}</strong></div>` : ''}
-          ${payload.customer ? `<div><span>Cliente</span><strong>${payload.customer}</strong></div>` : ''}
-          ${payload.createdAt ? `<div><span>Fecha</span><strong>${payload.createdAt}</strong></div>` : ''}
-          ${payload.paymentMethod ? `<div><span>Pago</span><strong>${payload.paymentMethod}</strong></div>` : ''}
-        </div>
-        <table>
-          <tbody>${itemsHtml}</tbody>
-        </table>
-        <div>${totalsHtml}</div>
-        <div class="footer">${payload.footer || 'Gracias por tu visita'}</div>
-      </body>
-    </html>
-  `
 }
 
 function createWindow() {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import type { TicketPrinterConfig } from './shared/ticketPrinter'
 
 const electronAPI = {
   getVersion: () => ipcRenderer.invoke('app:getVersion'),
@@ -19,6 +20,8 @@ const electronAPI = {
   },
   ticket: {
     listPrinters: () => ipcRenderer.invoke('ticket:listPrinters'),
+    getConfig: () => ipcRenderer.invoke('ticket:getConfig'),
+    setConfig: (config: TicketPrinterConfig) => ipcRenderer.invoke('ticket:setConfig', config),
     getPrinter: () => ipcRenderer.invoke('ticket:getPrinter'),
     setPrinter: (printerName: string | null) => ipcRenderer.invoke('ticket:setPrinter', printerName),
     print: (payload: any) => ipcRenderer.invoke('ticket:print', payload)
@@ -44,8 +47,10 @@ declare global {
       }
       ticket: {
         listPrinters: () => Promise<Array<{ name: string; displayName: string; isDefault: boolean }>>
+        getConfig: () => Promise<TicketPrinterConfig>
+        setConfig: (config: TicketPrinterConfig) => Promise<TicketPrinterConfig>
         getPrinter: () => Promise<{ ticketPrinterName: string | null }>
-        setPrinter: (printerName: string | null) => Promise<{ ticketPrinterName: string | null }>
+        setPrinter: (printerName: string | null) => Promise<TicketPrinterConfig>
         print: (payload: any) => Promise<{ success: boolean; error?: any }>
       }
     }

--- a/src/renderer/pages/ClientDetail.tsx
+++ b/src/renderer/pages/ClientDetail.tsx
@@ -36,6 +36,7 @@ import {
   deleteClientAsset,
   importClientAssets,
   isDesktop,
+  getPrintTicketSuccessMessage,
   listClientAssets,
   openClientFolder,
   printTicket,
@@ -258,8 +259,8 @@ export default function ClientDetail() {
   const handlePrintSale = async (saleId: string) => {
     try {
       const response = await api.get(`/sales/${saleId}`)
-      await printTicket(buildSaleTicketPayload(response.data))
-      toast.success('Ticket enviado a la impresora')
+      const printResult = await printTicket(buildSaleTicketPayload(response.data))
+      toast.success(getPrintTicketSuccessMessage(printResult))
     } catch (error: any) {
       toast.error(error.message || 'No se pudo imprimir el ticket')
     }

--- a/src/renderer/pages/Clients.tsx
+++ b/src/renderer/pages/Clients.tsx
@@ -20,7 +20,7 @@ import ClientCalendarDock from '../components/ClientCalendarDock'
 import ClientForm from '../components/ClientForm'
 import Modal from '../components/Modal'
 import api from '../utils/api'
-import { printTicket } from '../utils/desktop'
+import { getPrintTicketSuccessMessage, printTicket } from '../utils/desktop'
 import { formatCurrency, formatDate, formatPhone } from '../utils/format'
 import { buildSaleTicketPayload, paymentMethodLabel } from '../utils/tickets'
 
@@ -162,8 +162,8 @@ export default function Clients() {
   const handlePrintSale = async (saleId: string) => {
     try {
       const response = await api.get(`/sales/${saleId}`)
-      await printTicket(buildSaleTicketPayload(response.data))
-      toast.success('Ticket enviado a la impresora')
+      const printResult = await printTicket(buildSaleTicketPayload(response.data))
+      toast.success(getPrintTicketSuccessMessage(printResult))
     } catch (error: any) {
       toast.error(error.message || 'No se pudo imprimir el ticket')
     }

--- a/src/renderer/pages/Sales.tsx
+++ b/src/renderer/pages/Sales.tsx
@@ -18,6 +18,7 @@ import toast from 'react-hot-toast'
 import Modal from '../components/Modal'
 import api from '../utils/api'
 import { printTicket } from '../utils/desktop'
+import { getPrintTicketSuccessMessage } from '../utils/desktop'
 import { formatCurrency } from '../utils/format'
 import { buildSaleTicketPayload, paymentMethodLabel } from '../utils/tickets'
 
@@ -341,7 +342,8 @@ export default function Sales() {
       const createdSale = response.data
       if (options.printTicketAfterSale) {
         try {
-          await printTicket(buildSaleTicketPayload(createdSale))
+          const printResult = await printTicket(buildSaleTicketPayload(createdSale))
+          toast.success(getPrintTicketSuccessMessage(printResult))
         } catch (error: any) {
           toast.error(error.message || 'La venta se guardó, pero no se pudo imprimir el ticket')
         }
@@ -470,8 +472,8 @@ export default function Sales() {
 
   const handlePrintSale = async (sale: any) => {
     try {
-      await printTicket(buildSaleTicketPayload(sale))
-      toast.success('Ticket enviado a la impresora')
+      const printResult = await printTicket(buildSaleTicketPayload(sale))
+      toast.success(getPrintTicketSuccessMessage(printResult))
     } catch (error: any) {
       toast.error(error.message || 'No se pudo imprimir el ticket')
     }

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -2,14 +2,18 @@ import { useEffect, useMemo, useState } from 'react'
 import { AlertCircle, Calendar, CheckCircle2, Link2, Printer, RefreshCw, Save, Unlink } from 'lucide-react'
 import toast from 'react-hot-toast'
 import {
-  getConfiguredTicketPrinter,
   isDesktop,
+  getTicketPrinterConfig,
   listTicketPrinters,
-  setConfiguredTicketPrinter,
+  printTicket,
+  saveTicketPrinterConfig,
   TicketPrinter
 } from '../utils/desktop'
+import type { TicketPrinterConfig } from '../utils/desktop'
 import api from '../utils/api'
 import { useAuthStore } from '../stores/authStore'
+import { buildTestTicketPayload } from '../utils/tickets'
+import { DEFAULT_NETWORK_TICKET_PORT } from '../../shared/ticketPrinter'
 
 type GoogleCalendarConfig = {
   connected: boolean
@@ -31,8 +35,12 @@ export default function Settings() {
   const { user } = useAuthStore()
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [testingPrinter, setTestingPrinter] = useState(false)
   const [printers, setPrinters] = useState<TicketPrinter[]>([])
+  const [printerMode, setPrinterMode] = useState<TicketPrinterConfig['mode']>('system')
   const [selectedPrinter, setSelectedPrinter] = useState('')
+  const [networkHost, setNetworkHost] = useState('')
+  const [networkPort, setNetworkPort] = useState(String(DEFAULT_NETWORK_TICKET_PORT))
 
   const [calendarConfig, setCalendarConfig] = useState<GoogleCalendarConfig>(DEFAULT_CALENDAR_CONFIG)
   const [loadingCalendar, setLoadingCalendar] = useState(false)
@@ -58,11 +66,14 @@ export default function Settings() {
       setLoading(true)
       const [availablePrinters, configuredPrinter] = await Promise.all([
         listTicketPrinters(),
-        getConfiguredTicketPrinter()
+        getTicketPrinterConfig()
       ])
 
       setPrinters(availablePrinters)
-      setSelectedPrinter(configuredPrinter || availablePrinters.find((printer) => printer.isDefault)?.name || '')
+      setPrinterMode(configuredPrinter.mode)
+      setSelectedPrinter(configuredPrinter.ticketPrinterName || availablePrinters.find((printer) => printer.isDefault)?.name || '')
+      setNetworkHost(configuredPrinter.networkHost)
+      setNetworkPort(String(configuredPrinter.networkPort || DEFAULT_NETWORK_TICKET_PORT))
     } catch {
       toast.error('No se pudieron cargar las impresoras')
     } finally {
@@ -150,15 +161,64 @@ export default function Settings() {
     }
   }
 
+  const buildPrinterConfig = (): TicketPrinterConfig => ({
+    mode: printerMode,
+    ticketPrinterName: selectedPrinter || null,
+    networkHost: networkHost.trim(),
+    networkPort: Number(networkPort)
+  })
+
+  const validatePrinterConfig = (config: TicketPrinterConfig) => {
+    if (config.mode === 'system' && !config.ticketPrinterName) {
+      toast.error('Selecciona una impresora de Windows para el modo sistema')
+      return false
+    }
+
+    if (config.mode === 'network' && !config.networkHost) {
+      toast.error('Introduce la IP o el host de la impresora ESC/POS')
+      return false
+    }
+
+    if (!Number.isInteger(config.networkPort) || config.networkPort <= 0 || config.networkPort > 65535) {
+      toast.error('Introduce un puerto válido entre 1 y 65535')
+      return false
+    }
+
+    return true
+  }
+
   const handleSavePrinter = async () => {
+    const config = buildPrinterConfig()
+    if (!validatePrinterConfig(config)) {
+      return
+    }
+
     try {
       setSaving(true)
-      await setConfiguredTicketPrinter(selectedPrinter || null)
+      await saveTicketPrinterConfig(config)
       toast.success('Impresora de tickets configurada')
     } catch {
       toast.error('No se pudo guardar la impresora')
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handleTestPrinter = async () => {
+    const config = buildPrinterConfig()
+    if (!validatePrinterConfig(config)) {
+      return
+    }
+
+    try {
+      setTestingPrinter(true)
+      await saveTicketPrinterConfig(config)
+      await printTicket(buildTestTicketPayload())
+      toast.success('Ticket de prueba enviado')
+    } catch (error: any) {
+      toast.error(error.message || 'No se pudo imprimir el ticket de prueba')
+    } finally {
+      setTestingPrinter(false)
     }
   }
 
@@ -220,31 +280,101 @@ export default function Settings() {
           ) : (
             <>
               <div>
-                <label className="label">Impresora configurada</label>
+                <label className="label">Modo de conexión</label>
                 <select
-                  value={selectedPrinter}
-                  onChange={(event) => setSelectedPrinter(event.target.value)}
+                  value={printerMode}
+                  onChange={(event) => setPrinterMode(event.target.value as TicketPrinterConfig['mode'])}
                   className="input"
-                  disabled={loading}
+                  disabled={loading || saving || testingPrinter}
                 >
-                  <option value="">Sin seleccionar</option>
-                  {printers.map((printer) => (
-                    <option key={printer.name} value={printer.name}>
-                      {printer.displayName || printer.name}
-                      {printer.isDefault ? ' (predeterminada)' : ''}
-                    </option>
-                  ))}
+                  <option value="system">Impresora instalada en Windows</option>
+                  <option value="network">ESC/POS por red (LAN)</option>
                 </select>
+                <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                  Usa modo Windows si la impresora aparece en el sistema. Usa LAN si quieres enviar ESC/POS directo a la IP de la impresora.
+                </p>
               </div>
 
-              <button
-                onClick={handleSavePrinter}
-                className="btn btn-primary"
-                disabled={saving || loading || !selectedPrinter}
-              >
-                <Save className="mr-2 h-4 w-4" />
-                {saving ? 'Guardando...' : 'Guardar impresora'}
-              </button>
+              {printerMode === 'system' ? (
+                <div>
+                  <label className="label">Impresora configurada</label>
+                  <select
+                    value={selectedPrinter}
+                    onChange={(event) => setSelectedPrinter(event.target.value)}
+                    className="input"
+                    disabled={loading || saving || testingPrinter}
+                  >
+                    <option value="">Sin seleccionar</option>
+                    {printers.map((printer) => (
+                      <option key={printer.name} value={printer.name}>
+                        {printer.displayName || printer.name}
+                        {printer.isDefault ? ' (predeterminada)' : ''}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : (
+                <>
+                  <div>
+                    <label className="label">IP o host de la impresora</label>
+                    <input
+                      type="text"
+                      value={networkHost}
+                      onChange={(event) => setNetworkHost(event.target.value)}
+                      placeholder="192.168.1.50"
+                      className="input"
+                      disabled={loading || saving || testingPrinter}
+                    />
+                  </div>
+
+                  <div>
+                    <label className="label">Puerto TCP</label>
+                    <input
+                      type="number"
+                      min="1"
+                      max="65535"
+                      value={networkPort}
+                      onChange={(event) => setNetworkPort(event.target.value)}
+                      placeholder={String(DEFAULT_NETWORK_TICKET_PORT)}
+                      className="input"
+                      disabled={loading || saving || testingPrinter}
+                    />
+                    <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                      La mayoría de impresoras ESC/POS por red escuchan en el puerto `9100`.
+                    </p>
+                  </div>
+
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-200">
+                    Recomendación: para pruebas rápidas en portátil, la conexión LAN directa suele ser más estable que USB en Electron porque evita drivers y módulos nativos.
+                  </div>
+                </>
+              )}
+
+              <div className="flex flex-wrap gap-3">
+                <button
+                  onClick={handleSavePrinter}
+                  className="btn btn-primary"
+                  disabled={saving || loading || testingPrinter}
+                >
+                  <Save className="mr-2 h-4 w-4" />
+                  {saving ? 'Guardando...' : 'Guardar impresora'}
+                </button>
+
+                <button
+                  onClick={handleTestPrinter}
+                  className="btn btn-secondary"
+                  disabled={saving || loading || testingPrinter}
+                >
+                  <Printer className="mr-2 h-4 w-4" />
+                  {testingPrinter ? 'Imprimiendo...' : 'Imprimir prueba'}
+                </button>
+              </div>
+
+              {printerMode === 'system' && printers.length === 0 ? (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+                  No hay impresoras detectadas por Electron. Si la impresora no aparece en Windows, usa el modo LAN con IP fija o DHCP reservada.
+                </div>
+              ) : null}
             </>
           )}
         </div>
@@ -369,6 +499,10 @@ export default function Settings() {
             <p className="flex gap-2">
               <CheckCircle2 className="mt-0.5 h-4 w-4 text-green-600" />
               La impresora de tickets se configura por equipo; Google Calendar se configura una sola vez para toda la app.
+            </p>
+            <p className="flex gap-2">
+              <AlertCircle className="mt-0.5 h-4 w-4 text-amber-600" />
+              Para impresoras ESC/POS, prioriza LAN con IP conocida o impresora instalada en Windows; USB directo desde Electron suele requerir más mantenimiento.
             </p>
             <p className="flex gap-2">
               <AlertCircle className="mt-0.5 h-4 w-4 text-amber-600" />

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { AlertCircle, Calendar, CheckCircle2, Link2, Printer, RefreshCw, Save, Unlink } from 'lucide-react'
 import toast from 'react-hot-toast'
 import {
+  getPrintTicketSuccessMessage,
   isDesktop,
   getTicketPrinterConfig,
   listTicketPrinters,
@@ -205,16 +206,22 @@ export default function Settings() {
   }
 
   const handleTestPrinter = async () => {
-    const config = buildPrinterConfig()
-    if (!validatePrinterConfig(config)) {
-      return
-    }
-
     try {
       setTestingPrinter(true)
+      if (!desktopMode) {
+        const result = await printTicket(buildTestTicketPayload())
+        toast.success(getPrintTicketSuccessMessage(result))
+        return
+      }
+
+      const config = buildPrinterConfig()
+      if (!validatePrinterConfig(config)) {
+        return
+      }
+
       await saveTicketPrinterConfig(config)
-      await printTicket(buildTestTicketPayload())
-      toast.success('Ticket de prueba enviado')
+      const result = await printTicket(buildTestTicketPayload())
+      toast.success(getPrintTicketSuccessMessage(result))
     } catch (error: any) {
       toast.error(error.message || 'No se pudo imprimir el ticket de prueba')
     } finally {
@@ -274,8 +281,19 @@ export default function Settings() {
           </div>
 
           {!desktopMode ? (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
-              La configuración de impresora solo está disponible al abrir Lucy3000 como app de escritorio Electron.
+            <div className="space-y-4">
+              <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+                En navegador no hay acceso a Electron ni configuración silenciosa de impresora. Lucy3000 usará el diálogo de impresión del navegador y podrás elegir `POS-80c` manualmente.
+              </div>
+
+              <button
+                onClick={handleTestPrinter}
+                className="btn btn-primary"
+                disabled={testingPrinter}
+              >
+                <Printer className="mr-2 h-4 w-4" />
+                {testingPrinter ? 'Abriendo impresión...' : 'Imprimir prueba en navegador'}
+              </button>
             </div>
           ) : (
             <>
@@ -499,6 +517,10 @@ export default function Settings() {
             <p className="flex gap-2">
               <CheckCircle2 className="mt-0.5 h-4 w-4 text-green-600" />
               La impresora de tickets se configura por equipo; Google Calendar se configura una sola vez para toda la app.
+            </p>
+            <p className="flex gap-2">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 text-green-600" />
+              Si Lucy3000 se abre en navegador, el fallback usa el diálogo de impresión del sistema y aprovecha los drivers instalados en ese equipo.
             </p>
             <p className="flex gap-2">
               <AlertCircle className="mt-0.5 h-4 w-4 text-amber-600" />

--- a/src/renderer/utils/desktop.ts
+++ b/src/renderer/utils/desktop.ts
@@ -1,7 +1,8 @@
 import {
   DEFAULT_NETWORK_TICKET_PORT
 } from '../../shared/ticketPrinter'
-import type { TicketPrinterConfig } from '../../shared/ticketPrinter'
+import { buildTicketHtml } from '../../shared/ticketHtml'
+import type { TicketPrintPayload, TicketPrinterConfig } from '../../shared/ticketPrinter'
 
 export type ClientAssetKind = 'photos' | 'consents'
 
@@ -30,28 +31,91 @@ export type TicketPrinter = {
 }
 
 export type { TicketPrinterConfig }
-
-export type TicketPayload = {
-  title?: string
-  subtitle?: string
-  saleNumber?: string
-  customer?: string
-  createdAt?: string
-  paymentMethod?: string
-  items?: Array<{
-    description: string
-    quantity: number
-    unitPrice: number
-    total: number
-  }>
-  totals?: Array<{
-    label: string
-    value: string
-  }>
-  footer?: string
+export type TicketPayload = TicketPrintPayload
+export type TicketPrintResult = {
+  mode: 'desktop' | 'browser'
 }
 
 const desktopUnavailableError = 'Disponible solo en la app de escritorio'
+let browserPrintFrame: HTMLIFrameElement | null = null
+
+const removeBrowserPrintFrame = () => {
+  if (!browserPrintFrame) {
+    return
+  }
+
+  browserPrintFrame.remove()
+  browserPrintFrame = null
+}
+
+const printTicketInBrowser = async (payload: TicketPayload): Promise<TicketPrintResult> => {
+  if (typeof document === 'undefined') {
+    throw new Error('La impresión web no está disponible en este entorno')
+  }
+
+  removeBrowserPrintFrame()
+
+  const iframe = document.createElement('iframe')
+  iframe.setAttribute('aria-hidden', 'true')
+  iframe.style.position = 'fixed'
+  iframe.style.width = '0'
+  iframe.style.height = '0'
+  iframe.style.border = '0'
+  iframe.style.opacity = '0'
+  iframe.style.pointerEvents = 'none'
+  document.body.appendChild(iframe)
+  browserPrintFrame = iframe
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let fallbackTimer = 0
+
+    const finish = (error?: Error) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      window.clearTimeout(fallbackTimer)
+      if (browserPrintFrame === iframe) {
+        browserPrintFrame = null
+      }
+      iframe.remove()
+
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve({ mode: 'browser' })
+    }
+
+    iframe.onload = () => {
+      const frameWindow = iframe.contentWindow
+      if (!frameWindow) {
+        finish(new Error('No se pudo abrir la vista previa de impresión'))
+        return
+      }
+
+      const handleAfterPrint = () => {
+        frameWindow.removeEventListener('afterprint', handleAfterPrint)
+        finish()
+      }
+
+      frameWindow.addEventListener('afterprint', handleAfterPrint)
+      fallbackTimer = window.setTimeout(() => finish(), 1500)
+
+      try {
+        frameWindow.focus()
+        frameWindow.print()
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error('No se pudo abrir el diálogo de impresión'))
+      }
+    }
+
+    iframe.srcdoc = buildTicketHtml(payload)
+  })
+}
 
 export const isDesktop = () => Boolean(window.electronAPI)
 
@@ -153,13 +217,18 @@ export const saveTicketPrinterConfig = async (config: TicketPrinterConfig) => {
   return window.electronAPI.ticket.setConfig(config)
 }
 
-export const printTicket = async (payload: TicketPayload) => {
+export const getPrintTicketSuccessMessage = (result: TicketPrintResult) =>
+  result.mode === 'browser' ? 'Se abrió el diálogo de impresión del navegador' : 'Ticket enviado a la impresora'
+
+export const printTicket = async (payload: TicketPayload): Promise<TicketPrintResult> => {
   if (!window.electronAPI) {
-    throw new Error(desktopUnavailableError)
+    return printTicketInBrowser(payload)
   }
 
   const response = await window.electronAPI.ticket.print(payload)
   if (!response.success) {
     throw new Error(response.error || 'No se pudo imprimir el ticket')
   }
+
+  return { mode: 'desktop' }
 }

--- a/src/renderer/utils/desktop.ts
+++ b/src/renderer/utils/desktop.ts
@@ -1,3 +1,8 @@
+import {
+  DEFAULT_NETWORK_TICKET_PORT
+} from '../../shared/ticketPrinter'
+import type { TicketPrinterConfig } from '../../shared/ticketPrinter'
+
 export type ClientAssetKind = 'photos' | 'consents'
 
 export type ClientAsset = {
@@ -23,6 +28,8 @@ export type TicketPrinter = {
   displayName: string
   isDefault: boolean
 }
+
+export type { TicketPrinterConfig }
 
 export type TicketPayload = {
   title?: string
@@ -117,12 +124,33 @@ export const getConfiguredTicketPrinter = async (): Promise<string | null> => {
   return response.ticketPrinterName
 }
 
+export const getTicketPrinterConfig = async (): Promise<TicketPrinterConfig> => {
+  if (!window.electronAPI) {
+    return {
+      mode: 'system',
+      ticketPrinterName: null,
+      networkHost: '',
+      networkPort: DEFAULT_NETWORK_TICKET_PORT
+    }
+  }
+
+  return window.electronAPI.ticket.getConfig()
+}
+
 export const setConfiguredTicketPrinter = async (printerName: string | null) => {
   if (!window.electronAPI) {
     throw new Error(desktopUnavailableError)
   }
 
   return window.electronAPI.ticket.setPrinter(printerName)
+}
+
+export const saveTicketPrinterConfig = async (config: TicketPrinterConfig) => {
+  if (!window.electronAPI) {
+    throw new Error(desktopUnavailableError)
+  }
+
+  return window.electronAPI.ticket.setConfig(config)
 }
 
 export const printTicket = async (payload: TicketPayload) => {

--- a/src/renderer/utils/tickets.ts
+++ b/src/renderer/utils/tickets.ts
@@ -38,3 +38,22 @@ export const buildSaleTicketPayload = (sale: any): TicketPayload => ({
   ],
   footer: 'Gracias por confiar en Lucy3000'
 })
+
+export const buildTestTicketPayload = (): TicketPayload => ({
+  title: 'Lucy3000',
+  subtitle: 'Prueba de impresion',
+  saleNumber: 'TEST-0001',
+  customer: 'Cliente de prueba',
+  createdAt: formatDateTime(new Date().toISOString()),
+  paymentMethod: 'Efectivo',
+  items: [
+    {
+      description: 'Conexion impresora ticket',
+      quantity: 1,
+      unitPrice: 0,
+      total: 0
+    }
+  ],
+  totals: [{ label: 'Total', value: formatCurrency(0) }],
+  footer: 'Si ves este ticket, la conexion funciona'
+})

--- a/src/shared/ticketHtml.ts
+++ b/src/shared/ticketHtml.ts
@@ -1,0 +1,112 @@
+import type { TicketPrintPayload } from './ticketPrinter'
+
+export const buildTicketHtml = (payload: TicketPrintPayload) => {
+  const itemsHtml = (payload.items || [])
+    .map(
+      (item) => `
+        <tr>
+          <td class="desc">${item.description}</td>
+          <td class="qty">${item.quantity}</td>
+          <td class="amount">${item.total.toFixed(2)} €</td>
+        </tr>
+      `
+    )
+    .join('')
+
+  const totalsHtml = (payload.totals || [])
+    .map(
+      (total) => `
+        <div class="total-row">
+          <span>${total.label}</span>
+          <strong>${total.value}</strong>
+        </div>
+      `
+    )
+    .join('')
+
+  return `
+    <!DOCTYPE html>
+    <html lang="es">
+      <head>
+        <meta charset="UTF-8" />
+        <title>${payload.title || 'Lucy3000'}</title>
+        <style>
+          @page {
+            margin: 0;
+            size: 58mm auto;
+          }
+          body {
+            font-family: "Segoe UI", sans-serif;
+            width: 58mm;
+            margin: 0 auto;
+            padding: 8px;
+            color: #111827;
+            font-size: 12px;
+          }
+          h1 {
+            font-size: 18px;
+            margin: 0 0 4px;
+            text-align: center;
+          }
+          .muted {
+            text-align: center;
+            color: #4b5563;
+            margin-bottom: 8px;
+          }
+          .meta {
+            border-top: 1px dashed #9ca3af;
+            border-bottom: 1px dashed #9ca3af;
+            padding: 6px 0;
+            margin-bottom: 8px;
+          }
+          .meta div,
+          .total-row {
+            display: flex;
+            justify-content: space-between;
+            gap: 8px;
+            margin: 2px 0;
+          }
+          table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 8px;
+          }
+          td {
+            padding: 2px 0;
+            vertical-align: top;
+          }
+          .qty,
+          .amount {
+            white-space: nowrap;
+            text-align: right;
+          }
+          .desc {
+            width: 100%;
+            padding-right: 6px;
+          }
+          .footer {
+            border-top: 1px dashed #9ca3af;
+            padding-top: 8px;
+            text-align: center;
+            color: #4b5563;
+          }
+        </style>
+      </head>
+      <body>
+        <h1>${payload.title || 'Lucy3000'}</h1>
+        <div class="muted">${payload.subtitle || 'Ticket'}</div>
+        <div class="meta">
+          ${payload.saleNumber ? `<div><span>Ticket</span><strong>${payload.saleNumber}</strong></div>` : ''}
+          ${payload.customer ? `<div><span>Cliente</span><strong>${payload.customer}</strong></div>` : ''}
+          ${payload.createdAt ? `<div><span>Fecha</span><strong>${payload.createdAt}</strong></div>` : ''}
+          ${payload.paymentMethod ? `<div><span>Pago</span><strong>${payload.paymentMethod}</strong></div>` : ''}
+        </div>
+        <table>
+          <tbody>${itemsHtml}</tbody>
+        </table>
+        <div>${totalsHtml}</div>
+        <div class="footer">${payload.footer || 'Gracias por tu visita'}</div>
+      </body>
+    </html>
+  `
+}

--- a/src/shared/ticketPrinter.ts
+++ b/src/shared/ticketPrinter.ts
@@ -1,0 +1,83 @@
+export type TicketPrintPayload = {
+  title?: string
+  subtitle?: string
+  saleNumber?: string
+  customer?: string
+  createdAt?: string
+  paymentMethod?: string
+  items?: Array<{
+    description: string
+    quantity: number
+    unitPrice: number
+    total: number
+  }>
+  totals?: Array<{
+    label: string
+    value: string
+  }>
+  footer?: string
+}
+
+export type TicketPrinterMode = 'system' | 'network'
+
+export type TicketPrinterConfig = {
+  mode: TicketPrinterMode
+  ticketPrinterName: string | null
+  networkHost: string
+  networkPort: number
+}
+
+export const DEFAULT_NETWORK_TICKET_PORT = 9100
+
+export const DEFAULT_TICKET_PRINTER_CONFIG: TicketPrinterConfig = {
+  mode: 'system',
+  ticketPrinterName: null,
+  networkHost: '',
+  networkPort: DEFAULT_NETWORK_TICKET_PORT
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const cleanString = (value: unknown) => (typeof value === 'string' ? value.trim() : '')
+
+export const normalizeTicketPrinterConfig = (value: unknown): TicketPrinterConfig => {
+  if (!isRecord(value)) {
+    return { ...DEFAULT_TICKET_PRINTER_CONFIG }
+  }
+
+  const mode = value.mode === 'network' ? 'network' : 'system'
+  const ticketPrinterName = cleanString(value.ticketPrinterName) || null
+  const networkHost = cleanString(value.networkHost)
+  const rawPort = typeof value.networkPort === 'number' ? value.networkPort : Number(value.networkPort)
+  const networkPort = Number.isInteger(rawPort) && rawPort > 0 && rawPort <= 65535
+    ? rawPort
+    : DEFAULT_NETWORK_TICKET_PORT
+
+  return {
+    mode,
+    ticketPrinterName,
+    networkHost,
+    networkPort
+  }
+}
+
+export const validateTicketPrinterConfig = (config: TicketPrinterConfig) => {
+  if (config.mode === 'system') {
+    if (!config.ticketPrinterName) {
+      return { valid: false, error: 'No hay impresora de tickets configurada' }
+    }
+
+    return { valid: true as const }
+  }
+
+  if (!config.networkHost) {
+    return { valid: false, error: 'Falta la IP o el host de la impresora ESC/POS' }
+  }
+
+  if (!Number.isInteger(config.networkPort) || config.networkPort <= 0 || config.networkPort > 65535) {
+    return { valid: false, error: 'El puerto de la impresora debe estar entre 1 y 65535' }
+  }
+
+  return { valid: true as const }
+}

--- a/tests/backend/unit/ticket-printer.test.ts
+++ b/tests/backend/unit/ticket-printer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { buildEscPosTicketBuffer } from '../../../src/main/escpos'
+import { buildTicketHtml } from '../../../src/shared/ticketHtml'
 import {
   DEFAULT_NETWORK_TICKET_PORT,
   normalizeTicketPrinterConfig,
@@ -73,5 +74,30 @@ describe('ESC/POS ticket buffer', () => {
     expect(ascii).toContain('Maria Lopez')
     expect(ascii).toContain('Champu reparacion')
     expect(buffer.includes(Buffer.from([0x1d, 0x56, 0x00]))).toBe(true)
+  })
+})
+
+describe('ticket html', () => {
+  it('builds a printable document for browser and Electron', () => {
+    const html = buildTicketHtml({
+      title: 'Lucy3000',
+      subtitle: 'Ticket web',
+      saleNumber: 'WEB-1',
+      customer: 'Cliente Web',
+      items: [
+        {
+          description: 'Producto prueba',
+          quantity: 1,
+          unitPrice: 10,
+          total: 10
+        }
+      ],
+      totals: [{ label: 'Total', value: '10,00 EUR' }]
+    })
+
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('@page')
+    expect(html).toContain('Ticket web')
+    expect(html).toContain('Producto prueba')
   })
 })

--- a/tests/backend/unit/ticket-printer.test.ts
+++ b/tests/backend/unit/ticket-printer.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { buildEscPosTicketBuffer } from '../../../src/main/escpos'
+import {
+  DEFAULT_NETWORK_TICKET_PORT,
+  normalizeTicketPrinterConfig,
+  validateTicketPrinterConfig
+} from '../../../src/shared/ticketPrinter'
+
+describe('ticket printer config', () => {
+  it('normalizes legacy system printer config', () => {
+    const config = normalizeTicketPrinterConfig({
+      ticketPrinterName: 'POS-80'
+    })
+
+    expect(config).toEqual({
+      mode: 'system',
+      ticketPrinterName: 'POS-80',
+      networkHost: '',
+      networkPort: DEFAULT_NETWORK_TICKET_PORT
+    })
+  })
+
+  it('validates network printer host and port', () => {
+    expect(
+      validateTicketPrinterConfig({
+        mode: 'network',
+        ticketPrinterName: null,
+        networkHost: '',
+        networkPort: 9100
+      })
+    ).toEqual({
+      valid: false,
+      error: 'Falta la IP o el host de la impresora ESC/POS'
+    })
+
+    expect(
+      validateTicketPrinterConfig({
+        mode: 'network',
+        ticketPrinterName: null,
+        networkHost: '192.168.1.50',
+        networkPort: 9100
+      })
+    ).toEqual({
+      valid: true
+    })
+  })
+})
+
+describe('ESC/POS ticket buffer', () => {
+  it('builds an ASCII-safe receipt with cut command', () => {
+    const buffer = buildEscPosTicketBuffer({
+      title: 'Lucy3000',
+      subtitle: 'Prueba de impresión',
+      saleNumber: 'TEST-1',
+      customer: 'María López',
+      paymentMethod: 'Tarjeta',
+      items: [
+        {
+          description: 'Champú reparación',
+          quantity: 1,
+          unitPrice: 12.5,
+          total: 12.5
+        }
+      ],
+      totals: [{ label: 'Total', value: '12,50 EUR' }],
+      footer: 'Gracias por tu visita'
+    })
+
+    const ascii = buffer.toString('ascii')
+
+    expect(buffer.at(0)).toBe(0x1b)
+    expect(ascii).toContain('Prueba de impresion')
+    expect(ascii).toContain('Maria Lopez')
+    expect(ascii).toContain('Champu reparacion')
+    expect(buffer.includes(Buffer.from([0x1d, 0x56, 0x00]))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add a second ticket printer mode for direct ESC/POS printing over LAN while keeping the existing Windows printer flow
- expose printer mode, host/port configuration, and a test print action in Settings
- add ticket printer config helpers and tests for config normalization and ESC/POS buffer generation

## Validation
- 
px tsc -p tsconfig.json --noEmit
- 
px vite build
- 
pm run build:backend
- 
pm run test:unit

## Notes
- local-only files such as .env.development, .claude/*, .cline/*, and .env.prisma_temp were intentionally excluded from this PR