### PR TITLE
feat: trial autoservicio (PENDING + hora de servidor + start-trial)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,33 @@ La topologia real actual es React/Vite + Express + Prisma + PostgreSQL multi-ten
 Supabase es una opcion de infraestructura para Postgres/Storage, no una autorizacion directa desde el frontend.
 SQLite queda como legado de migracion, importacion o soporte puntual.
 
+## Modelo de distribucion vigente (2026-05-31)
+
+Decision de Sergio: distribuir como **app Electron instalada por cliente**, cada
+instalacion contra **su propio proyecto Supabase** (datos aislados entre negocios,
+sin servidor central, sin cuota ni cold start). El control de trial vive en la
+tabla `tenant_licenses` del Supabase del cliente y usa **hora de servidor**
+(`getServerNow()` -> `SELECT NOW()`), no el reloj del PC.
+
+Flujo de licencia: bootstrap en modo Supabase nace `PENDING`; el admin del tenant
+arranca su prueba con `POST /api/tenants/current/start-trial` (boton "Empezar
+prueba"); gracia `PENDING_GRACE_DAYS` (9 dias) antes del bloqueo definitivo
+(`pending-expired`). Alta por cliente: crear Supabase -> `prisma migrate deploy`
+-> instalar .exe modo Supabase -> bootstrap -> empezar prueba.
+
+<!--
+  CANAL CENTRAL WEB/PWA EN RENDER (DORMIDO, no usado por el modelo vigente).
+  Se monto el 2026-05-31 por si en el futuro se vuelve a un SaaS central:
+    - render.yaml (Blueprint) en la raiz define lucy3000-api + lucy3000-web.
+    - Workspace Render "Lucy3000" tea-d8dlksh9rddc73a25e50 (cuenta sergio.hlara84).
+    - Servicio API: srv-d8dlmoojs32c73fmfee0  -> https://lucy3000-2hnv.onrender.com
+    - Servicio front estatico: srv-d8dlqkvavr4c73ft9kl0 -> https://lucy3000-web.onrender.com
+    - El front PWA (public/manifest.webmanifest, public/sw.js, public/_redirects)
+      y los scripts build:web / deploy:web siguen en el repo, inertes para Electron.
+  Si se reactiva: poner DATABASE_URL/BOOTSTRAP_TOKEN en la API y VITE_API_URL en el front.
+-->
+
+
 ## Fuentes de verdad
 
 Cuando una instruccion o documento entre en conflicto, usa este orden:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,12 @@ La guia detallada vive en `AGENTS.md`.
 4. `ARCHITECTURE.md`
 5. `AGENTS.md`
 
+## Distribucion vigente (2026-05-31)
+
+- Modelo elegido: app Electron por cliente, cada una contra su propio Supabase. Sin servidor central.
+- Trial controlado en `tenant_licenses` con hora de servidor; bootstrap nace `PENDING`, el cliente arranca con `start-trial`, gracia de 9 dias.
+- El canal central web/PWA en Render queda DORMIDO (no borrado). Detalle e IDs en el comentario de `AGENTS.md` y en `render.yaml`.
+
 ## Resumen operativo
 
 - Runtime oficial de datos: API central Express + Prisma + PostgreSQL multi-tenant.

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,10 @@
+# DORMIDO (2026-05-31): el modelo vigente es Electron por cliente contra su
+# propio Supabase, sin servidor central (ver CLAUDE.md / AGENTS.md). Este
+# Blueprint se conserva por si en el futuro se vuelve a un SaaS central.
+# Servicios ya creados (cuenta sergio.hlara84, workspace tea-d8dlksh9rddc73a25e50):
+#   API  srv-d8dlmoojs32c73fmfee0  https://lucy3000-2hnv.onrender.com
+#   web  srv-d8dlqkvavr4c73ft9kl0  https://lucy3000-web.onrender.com
+#
 # Blueprint de Render para Lucy3000.
 # Despliega dos servicios desde este repo:
 #   - lucy3000-api : API central Express + Prisma (consume el PostgreSQL de Supabase).

--- a/src/backend/controllers/auth.controller.ts
+++ b/src/backend/controllers/auth.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express'
 import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
-import { prisma } from '../db'
+import { getServerNow, prisma } from '../db'
 import { AuthRequest } from '../middleware/auth.middleware'
 import { evaluateTenantLicense, getTrialEndDate } from '../tenant/license'
 import { getJwtSecret } from '../utils/jwt'
@@ -48,10 +48,11 @@ const buildAuthResponse = (user: {
       trialEndsAt: Date
       blockedAt?: Date | null
       cancelledAt?: Date | null
+      createdAt?: Date | null
     } | null
   }
-}) => {
-  const license = user.tenant?.license ? evaluateTenantLicense(user.tenant.license) : null
+}, now?: Date) => {
+  const license = user.tenant?.license ? evaluateTenantLicense(user.tenant.license, now) : null
   const token = jwt.sign(
     {
       id: user.id,
@@ -133,8 +134,12 @@ export const bootstrapAdmin = async (req: Request, res: Response) => {
           slug: tenantSlug,
           license: {
             create: {
-              status: isLocalSqliteMode() ? 'ACTIVE' : 'TRIAL',
-              plan: isLocalSqliteMode() ? 'local' : 'trial',
+              // SQLite local = ACTIVE de por vida (sin control de trial).
+              // Supabase = PENDING: la prueba no arranca en la instalacion;
+              // el cliente la inicia con el pop-up "Empezar prueba" (start-trial)
+              // y dispone de una gracia para configurar antes (PENDING_GRACE_DAYS).
+              status: isLocalSqliteMode() ? 'ACTIVE' : 'PENDING',
+              plan: isLocalSqliteMode() ? 'local' : 'pending',
               trialEndsAt: isLocalSqliteMode() ? new Date('2099-12-31T23:59:59.000Z') : getTrialEndDate(),
               activatedAt: isLocalSqliteMode() ? new Date() : undefined
             }
@@ -218,7 +223,8 @@ export const login = async (req: Request, res: Response) => {
       return res.status(403).json({ error: 'Tenant is not active' })
     }
 
-    const licenseAccess = evaluateTenantLicense(user.tenant.license)
+    const serverNow = await getServerNow()
+    const licenseAccess = evaluateTenantLicense(user.tenant.license, serverNow)
 
     const isValidPassword = await bcrypt.compare(password, user.password)
 
@@ -230,7 +236,7 @@ export const login = async (req: Request, res: Response) => {
       return res.status(401).json({ error: 'User is inactive' })
     }
 
-    res.status(licenseAccess.allowed ? 200 : 402).json(buildAuthResponse(user))
+    res.status(licenseAccess.allowed ? 200 : 402).json(buildAuthResponse(user, serverNow))
   } catch (error) {
     console.error('Login error:', error)
     res.status(500).json({ error: 'Internal server error' })
@@ -332,7 +338,8 @@ export const getCurrentUser = async (req: AuthRequest, res: Response) => {
                 plan: true,
                 trialEndsAt: true,
                 blockedAt: true,
-                cancelledAt: true
+                cancelledAt: true,
+                createdAt: true
               }
             }
           }
@@ -344,7 +351,9 @@ export const getCurrentUser = async (req: AuthRequest, res: Response) => {
       return res.status(404).json({ error: 'User not found' })
     }
 
-    const license = user.tenant.license ? evaluateTenantLicense(user.tenant.license) : null
+    const license = user.tenant.license
+      ? evaluateTenantLicense(user.tenant.license, await getServerNow())
+      : null
 
     res.json({
       ...user,

--- a/src/backend/controllers/tenant.controller.ts
+++ b/src/backend/controllers/tenant.controller.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express'
 import bcrypt from 'bcryptjs'
-import { prisma } from '../db'
+import { getServerNow, prisma } from '../db'
 import type { AuthRequest } from '../middleware/auth.middleware'
 import { evaluateTenantLicense, getTrialEndDate } from '../tenant/license'
 
@@ -76,7 +76,7 @@ export const getCurrentTenantLicense = async (req: AuthRequest, res: Response) =
       return res.status(404).json({ error: 'Tenant license not found' })
     }
 
-    const license = evaluateTenantLicense(tenant.license)
+    const license = evaluateTenantLicense(tenant.license, await getServerNow())
     res.json({
       tenant: {
         id: tenant.id,
@@ -99,6 +99,55 @@ export const getCurrentTenantLicense = async (req: AuthRequest, res: Response) =
     res.status(500).json({ error: 'Internal server error' })
   }
 }
+// El propio admin del tenant arranca su prueba de 7 dias (boton "Si" del
+// pop-up). Solo permitido desde PENDING y dentro de la gracia; el reloj se
+// fija con la hora de la base (Supabase), no la del PC.
+export const startCurrentTenantTrial = async (req: AuthRequest, res: Response) => {
+  try {
+    const tenantId = req.user?.tenantId
+    if (!tenantId) {
+      return res.status(401).json({ error: 'Tenant context is required' })
+    }
+
+    const license = await prisma.tenantLicense.findUnique({ where: { tenantId } })
+    if (!license) {
+      return res.status(404).json({ error: 'Tenant license not found' })
+    }
+
+    if (license.status !== 'PENDING') {
+      return res.status(409).json({ error: 'Trial can only be started from a pending license' })
+    }
+
+    const now = await getServerNow()
+    const access = evaluateTenantLicense(license, now)
+    if (access.reason === 'pending-expired') {
+      return res.status(403).json({ error: 'Trial grace period has expired', reason: 'pending-expired' })
+    }
+
+    const trialEndsAt = getTrialEndDate(now)
+    const updated = await prisma.tenantLicense.update({
+      where: { tenantId },
+      data: {
+        status: 'TRIAL',
+        plan: 'trial',
+        trialEndsAt,
+        blockedAt: null,
+        cancelledAt: null
+      }
+    })
+
+    const updatedAccess = evaluateTenantLicense(updated, now)
+    res.json({
+      status: updatedAccess.status,
+      reason: updatedAccess.reason,
+      trialEndsAt: updated.trialEndsAt
+    })
+  } catch (error) {
+    console.error('Start tenant trial error:', error)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
 export const getTenants = async (_req: AuthRequest, res: Response) => {
   try {
     const tenants = await prisma.tenant.findMany({

--- a/src/backend/db.ts
+++ b/src/backend/db.ts
@@ -306,6 +306,24 @@ if (process.env.NODE_ENV !== 'production') {
   globalForPrisma.__lucyPrisma = prisma
 }
 
+// Hora autoritativa para decisiones de licencia/trial. En modo Postgres
+// (Supabase) la toma de la base con SELECT NOW(), de forma que cambiar el reloj
+// del PC del cliente no alarga ni adelanta el trial. En SQLite local cae a la
+// hora local del proceso.
+export const getServerNow = async (): Promise<Date> => {
+  if (process.env.DATABASE_URL?.startsWith('file:')) {
+    return new Date()
+  }
+
+  try {
+    const rows = await prisma.$queryRawUnsafe<Array<{ now: Date }>>('SELECT NOW() as now')
+    const value = rows?.[0]?.now
+    return value ? new Date(value) : new Date()
+  } catch {
+    return new Date()
+  }
+}
+
 export const ensureSqliteCompatibilityMigrations = async () => {
   if (!process.env.DATABASE_URL?.startsWith('file:')) {
     return

--- a/src/backend/middleware/auth.middleware.ts
+++ b/src/backend/middleware/auth.middleware.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express'
 import jwt from 'jsonwebtoken'
-import { prisma } from '../db'
+import { getServerNow, prisma } from '../db'
 import { runWithTenantContext } from '../tenant/context'
 import { evaluateTenantLicense } from '../tenant/license'
 import { getJwtSecret } from '../utils/jwt'
@@ -20,7 +20,10 @@ export interface AuthRequest extends Request {
 
 const LICENSE_BYPASS_PATHS = new Set([
   '/api/auth/me',
-  '/api/tenants/current/license'
+  '/api/tenants/current/license',
+  // El cliente puede arrancar su prueba estando PENDING (licencia no activa),
+  // por eso este endpoint no debe bloquearse por el gate de licencia.
+  '/api/tenants/current/start-trial'
 ])
 
 const isLicenseBypassRequest = (req: Request) => {
@@ -89,7 +92,7 @@ export const authMiddleware = async (req: AuthRequest, res: Response, next: Next
       return res.status(403).json({ error: 'Tenant is not active' })
     }
 
-    const licenseAccess = evaluateTenantLicense(user.tenant.license)
+    const licenseAccess = evaluateTenantLicense(user.tenant.license, await getServerNow())
 
     req.user = {
       id: user.id,

--- a/src/backend/routes/tenant.routes.ts
+++ b/src/backend/routes/tenant.routes.ts
@@ -3,6 +3,7 @@ import {
   createTenant,
   getCurrentTenantLicense,
   getTenants,
+  startCurrentTenantTrial,
   updateTenantLicense
 } from '../controllers/tenant.controller'
 import { authMiddleware, platformAdminMiddleware } from '../middleware/auth.middleware'
@@ -18,6 +19,7 @@ const router = Router()
 router.use(authMiddleware)
 
 router.get('/current/license', getCurrentTenantLicense)
+router.post('/current/start-trial', startCurrentTenantTrial)
 
 router.use(platformAdminMiddleware)
 

--- a/src/backend/tenant/license.ts
+++ b/src/backend/tenant/license.ts
@@ -6,16 +6,29 @@ export type TenantLicenseSnapshot = {
   trialEndsAt: Date
   blockedAt?: Date | null
   cancelledAt?: Date | null
+  createdAt?: Date | null
 }
 
 export type TenantLicenseAccess = {
   allowed: boolean
   status: string
-  reason: 'active' | 'trial-expired' | 'blocked' | 'cancelled' | 'pending' | 'inactive'
+  reason:
+    | 'active'
+    | 'trial-expired'
+    | 'blocked'
+    | 'cancelled'
+    | 'pending'
+    | 'pending-expired'
+    | 'inactive'
   trialEndsAt: Date
 }
 
 export const TRIAL_DAYS = 7
+
+// Dias que un tenant PENDING puede quedarse sin arrancar la prueba antes de
+// bloquearse del todo. Permite instalar, configurar y posponer el "Si" del
+// pop-up varios dias (peor caso: dia 9). El dia 10 ya no deja entrar.
+export const PENDING_GRACE_DAYS = 9
 
 export const getTrialEndDate = (startedAt = new Date()) => {
   const trialEndsAt = new Date(startedAt)
@@ -46,10 +59,16 @@ export const evaluateTenantLicense = (
   }
 
   if (license.status === 'PENDING') {
+    let pendingExpired = false
+    if (license.createdAt) {
+      const graceEnd = new Date(license.createdAt)
+      graceEnd.setDate(graceEnd.getDate() + PENDING_GRACE_DAYS)
+      pendingExpired = graceEnd.getTime() < now.getTime()
+    }
     return {
       allowed: false,
       status: 'PENDING',
-      reason: 'pending',
+      reason: pendingExpired ? 'pending-expired' : 'pending',
       trialEndsAt: license.trialEndsAt
     }
   }

--- a/src/renderer/pages/LicenseBlocked.tsx
+++ b/src/renderer/pages/LicenseBlocked.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Clock, Lock, RefreshCw, LogOut, Hourglass } from 'lucide-react'
+import { Clock, Lock, RefreshCw, LogOut, Hourglass, PlayCircle } from 'lucide-react'
 import { useAuthStore } from '../stores/authStore'
 import api from '../utils/api'
 import toast from 'react-hot-toast'
@@ -27,9 +27,15 @@ const REASON_CONTENT: Record<
 > = {
   pending: {
     icon: Hourglass,
-    title: 'Cuenta pendiente de activacion',
+    title: 'Tu cuenta esta lista',
     description:
-      'Tu centro esta configurado pero la prueba todavia no ha comenzado. En cuanto terminemos de preparar tus datos activaremos tu periodo de prueba de 7 dias y podras entrar.'
+      'Cuando termines de configurar tu centro, empieza tu prueba gratuita de 7 dias. Hasta entonces puedes cerrar y volver otro dia; el reloj solo arranca cuando pulses "Empezar prueba".'
+  },
+  'pending-expired': {
+    icon: Lock,
+    title: 'Periodo de preparacion agotado',
+    description:
+      'Ha pasado el plazo para iniciar la prueba sin activarla. Ponte en contacto con soporte de Lucy3000 para activar tu cuenta.'
   },
   'trial-expired': {
     icon: Clock,
@@ -60,10 +66,26 @@ const REASON_CONTENT: Record<
 export default function LicenseBlocked({ license }: { license: LicenseInfo }) {
   const { user, updateUser, logout } = useAuthStore()
   const [refreshing, setRefreshing] = useState(false)
+  const [startingTrial, setStartingTrial] = useState(false)
 
   const content = REASON_CONTENT[license.reason] ?? REASON_CONTENT.inactive
   const Icon = content.icon
   const trialDate = formatDate(license.trialEndsAt)
+  const canStartTrial = license.reason === 'pending'
+
+  const handleStartTrial = async () => {
+    setStartingTrial(true)
+    try {
+      await api.post('/tenants/current/start-trial')
+      const me = await api.get('/auth/me')
+      updateUser({ ...(user as any), ...me.data })
+      toast.success('Prueba de 7 dias iniciada. ¡A trabajar!')
+    } catch (error: any) {
+      toast.error(error.response?.data?.error || 'No se pudo iniciar la prueba')
+    } finally {
+      setStartingTrial(false)
+    }
+  }
 
   const handleRefresh = async () => {
     setRefreshing(true)
@@ -107,15 +129,27 @@ export default function LicenseBlocked({ license }: { license: LicenseInfo }) {
             ) : null}
 
             <div className="mt-8 w-full space-y-3">
-              <button
-                type="button"
-                onClick={handleRefresh}
-                disabled={refreshing}
-                className="w-full btn btn-primary py-3 flex items-center justify-center gap-2"
-              >
-                <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
-                {refreshing ? 'Comprobando...' : 'Ya esta activo, comprobar de nuevo'}
-              </button>
+              {canStartTrial ? (
+                <button
+                  type="button"
+                  onClick={handleStartTrial}
+                  disabled={startingTrial}
+                  className="w-full btn btn-primary py-3 flex items-center justify-center gap-2"
+                >
+                  <PlayCircle className="w-4 h-4" />
+                  {startingTrial ? 'Iniciando prueba...' : 'Empezar prueba de 7 dias'}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleRefresh}
+                  disabled={refreshing}
+                  className="w-full btn btn-primary py-3 flex items-center justify-center gap-2"
+                >
+                  <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
+                  {refreshing ? 'Comprobando...' : 'Ya esta activo, comprobar de nuevo'}
+                </button>
+              )}
               <button
                 type="button"
                 onClick={logout}

--- a/tests/backend/unit/license.test.ts
+++ b/tests/backend/unit/license.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import {
+  evaluateTenantLicense,
+  getTrialEndDate,
+  PENDING_GRACE_DAYS,
+  type TenantLicenseSnapshot
+} from '../../../src/backend/tenant/license'
+
+const baseLicense = (overrides: Partial<TenantLicenseSnapshot> = {}): TenantLicenseSnapshot => ({
+  status: 'PENDING',
+  plan: 'pending',
+  trialEndsAt: new Date('2099-12-31T00:00:00.000Z'),
+  blockedAt: null,
+  cancelledAt: null,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  ...overrides
+})
+
+const daysFrom = (base: Date, days: number) => {
+  const d = new Date(base)
+  d.setDate(d.getDate() + days)
+  return d
+}
+
+describe('evaluateTenantLicense', () => {
+  it('blocks an ACTIVE/expired-trial check using the provided (server) now', () => {
+    const license = baseLicense({ status: 'TRIAL', trialEndsAt: new Date('2026-01-05T00:00:00.000Z') })
+    const beforeExpiry = evaluateTenantLicense(license, new Date('2026-01-04T00:00:00.000Z'))
+    const afterExpiry = evaluateTenantLicense(license, new Date('2026-01-06T00:00:00.000Z'))
+
+    expect(beforeExpiry.allowed).toBe(true)
+    expect(beforeExpiry.reason).toBe('active')
+    expect(afterExpiry.allowed).toBe(false)
+    expect(afterExpiry.reason).toBe('trial-expired')
+  })
+
+  it('keeps PENDING within the grace window as reason "pending"', () => {
+    const createdAt = new Date('2026-01-01T00:00:00.000Z')
+    const license = baseLicense({ createdAt })
+    const now = daysFrom(createdAt, PENDING_GRACE_DAYS - 1)
+
+    const access = evaluateTenantLicense(license, now)
+    expect(access.allowed).toBe(false)
+    expect(access.reason).toBe('pending')
+  })
+
+  it('marks PENDING past the grace window as reason "pending-expired"', () => {
+    const createdAt = new Date('2026-01-01T00:00:00.000Z')
+    const license = baseLicense({ createdAt })
+    const now = daysFrom(createdAt, PENDING_GRACE_DAYS + 1)
+
+    const access = evaluateTenantLicense(license, now)
+    expect(access.allowed).toBe(false)
+    expect(access.reason).toBe('pending-expired')
+  })
+
+  it('treats BLOCKED and CANCELLED before pending grace', () => {
+    expect(evaluateTenantLicense(baseLicense({ status: 'BLOCKED' })).reason).toBe('blocked')
+    expect(evaluateTenantLicense(baseLicense({ status: 'CANCELLED' })).reason).toBe('cancelled')
+  })
+
+  it('allows ACTIVE licenses', () => {
+    const access = evaluateTenantLicense(baseLicense({ status: 'ACTIVE' }))
+    expect(access.allowed).toBe(true)
+    expect(access.reason).toBe('active')
+  })
+
+  it('getTrialEndDate adds 7 days to the given start', () => {
+    const start = new Date('2026-03-01T00:00:00.000Z')
+    expect(getTrialEndDate(start).toISOString()).toBe('2026-03-08T00:00:00.000Z')
+  })
+})


### PR DESCRIPTION
## Contexto

Pivote de modelo: distribucion como **app Electron local por cliente**, cada una contra **su propio Supabase** (datos aislados, sin servidor central, sin cold start). La licencia/trial se controla con datos en Supabase y **hora de servidor**.

## Cambios

### Backend
- **bootstrap** en modo Supabase nace `PENDING` (la prueba no arranca al instalar).
- **`getServerNow()`**: la hora para decidir licencia/trial viene de la base (`SELECT NOW()`), no del PC. Cambiar el reloj del portatil ya no alarga la prueba. La usan login, middleware y `/me`.
- **Gracia PENDING** (`PENDING_GRACE_DAYS = 9`): dentro → `reason 'pending'`; pasada → `reason 'pending-expired'` (bloqueo total).
- **`POST /api/tenants/current/start-trial`**: el admin del propio tenant arranca sus 7 dias (boton "Si"), solo desde PENDING y dentro de la gracia, con `trialEndsAt = NOW()+7`.

### Frontend
- Pantalla PENDING con boton **"Empezar prueba de 7 dias"** → llama a start-trial y recarga.
- Estado `pending-expired` como bloqueo sin boton.

## Tests
- 340 previos + 6 nuevos de `license` (gracia/pending-expired/server-now). Typecheck + build OK.

## Nota
Con este modelo, **Render deja de ser necesario** (era para el canal central web/PWA). Pendiente: limpiar los servicios de Render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)