### PR TITLE
feat: /promotion, / redirect, /dashboard→/panel

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -190,11 +190,12 @@ function App() {
 
       <Suspense fallback={<RouteLoader />}>
         <Routes>
-          <Route path="/" element={!isAuthenticated ? <PublicAccess /> : <Navigate to="/app/dashboard" />} />
+          <Route path="/" element={<Navigate to={isAuthenticated ? '/app/dashboard' : '/login'} replace />} />
+          <Route path="/promotion" element={<PublicAccess />} />
           <Route path="/login" element={!isAuthenticated ? <Login /> : <Navigate to="/app/dashboard" />} />
-          <Route path="/forgot-password" element={!isAuthenticated ? <ForgotPassword /> : <Navigate to="/" />} />
-          <Route path="/reset-password" element={!isAuthenticated ? <ResetPassword /> : <Navigate to="/" />} />
-          <Route path="/dashboard" element={<PlatformDashboard />} />
+          <Route path="/forgot-password" element={!isAuthenticated ? <ForgotPassword /> : <Navigate to="/login" />} />
+          <Route path="/reset-password" element={!isAuthenticated ? <ResetPassword /> : <Navigate to="/login" />} />
+          <Route path="/panel" element={<PlatformDashboard />} />
 
           <Route element={isAuthenticated ? <LicensedArea /> : <Navigate to="/login" />}>
             <Route path="/app/dashboard" element={<Dashboard />} />


### PR DESCRIPTION
## Summary
- `/` → redirect puro (`/app/dashboard` si autenticado, `/login` si no)
- `/promotion` → PublicAccess (solicitar información), siempre público
- `/panel` → PlatformDashboard (antes `/dashboard`)
- forgot/reset-password redirigen a `/login` en vez de `/`

## Test plan
- [ ] `lucy3000-web.onrender.com/` redirige a `/login` sin sesión
- [ ] `lucy3000-web.onrender.com/` redirige a `/app/dashboard` con sesión
- [ ] `lucy3000-web.onrender.com/promotion` muestra formulario "Solicitar información"
- [ ] `lucy3000-web.onrender.com/panel` muestra PlatformDashboard
- [ ] `/dashboard` ya no existe (404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)